### PR TITLE
Pass options to parseConfig on watch

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -128,7 +128,7 @@ if (cli.flags.watch) {
     spinner.start('updating...')
     delete require.cache[require.resolve(file)]
     const next = require(file)
-    parseConfig(next)
+    parseConfig(next, cli.flags)
     spinner.succeed('updated')
   })
 } else {


### PR DESCRIPTION
```
❯ lab -wd dist
 L A B  @compositor/lab
✔ 1 components found
✔ dist/Button.js written
ℹ watching for changes
⠋ updating.../usr/local/lib/node_modules/@compositor/lab/bin/cli.js:88
  if (options.pkg) {
             ^

TypeError: Cannot read property 'pkg' of undefined
    at parseConfig (/usr/local/lib/node_modules/@compositor/lab/bin/cli.js:88:14)
    at FSWatcher.watcher.on.file (/usr/local/lib/node_modules/@compositor/lab/bin/cli.js:131:5)
    at emitOne (events.js:115:13)
    at FSWatcher.emit (events.js:210:7)
    at FSWatcher.<anonymous> (/usr/local/lib/node_modules/@compositor/lab/node_modules/chokidar/index.js:196:15)
    at FSWatcher._emit (/usr/local/lib/node_modules/@compositor/lab/node_modules/chokidar/index.js:238:5)
    at FSWatcher.<anonymous> (/usr/local/lib/node_modules/@compositor/lab/node_modules/chokidar/lib/fsevents-handler.js:204:14)
    at addOrChange (/usr/local/lib/node_modules/@compositor/lab/node_modules/chokidar/lib/fsevents-handler.js:210:7)
    at /usr/local/lib/node_modules/@compositor/lab/node_modules/chokidar/lib/fsevents-handler.js:216:35
    at FSReqWrap.oncomplete (fs.js:136:15)
```